### PR TITLE
fix: discard build output artifact path

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -21,3 +21,4 @@ artifacts:
   files:
     - dist/sagemaker_inference-*.tar.gz
   name: ARTIFACT_1
+  discard-paths: yes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- discard build output path for artifact so that build deploy can find the file package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
