### PR TITLE
fix: wait for mms server process to finish instead of tailing dev null

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 packages = setuptools.find_packages(where='src', exclude=('test',))
 
 required_packages = [
-    'numpy', 'six', 'typing', 'psutil'
+    'numpy', 'six', 'typing', 'psutil', 'retrying==1.3.3'
 ]
 
 # enum is introduced in Python 3.4. Installing enum back port

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 packages = setuptools.find_packages(where='src', exclude=('test',))
 
 required_packages = [
-    'numpy', 'six', 'typing'
+    'numpy', 'six', 'typing', 'psutil'
 ]
 
 # enum is introduced in Python 3.4. Installing enum back port

--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -17,6 +17,7 @@ import signal
 import subprocess
 
 import pkg_resources
+import psutil
 
 import sagemaker_inference
 from sagemaker_inference import default_handler_service, environment, logging, utils
@@ -31,6 +32,7 @@ DEFAULT_MMS_MODEL_DIRECTORY = os.path.join(os.getcwd(), '.sagemaker/mms/models')
 DEFAULT_MMS_MODEL_NAME = 'model'
 
 PYTHON_PATH_ENV = 'PYTHONPATH'
+MMS_NAMESPACE = "com.amazonaws.ml.mms.ModelServer"
 
 
 def start_model_server(handler_service=DEFAULT_HANDLER_SERVICE):
@@ -54,13 +56,13 @@ def start_model_server(handler_service=DEFAULT_HANDLER_SERVICE):
                               ]
 
     logger.info(mxnet_model_server_cmd)
-    mms_process = subprocess.Popen(mxnet_model_server_cmd)
+    subprocess.Popen(mxnet_model_server_cmd)
+
+    mms_process = _retrieve_mms_server_process()
 
     _add_sigterm_handler(mms_process)
 
-    subprocess.call(['tail',
-                     '-f',
-                     '/dev/null'])
+    mms_process.wait()
 
 
 def _adapt_to_mms_format(handler_service):
@@ -129,3 +131,19 @@ def _add_sigterm_handler(mms_process):
             pass
 
     signal.signal(signal.SIGTERM, _terminate)
+
+
+def _retrieve_mms_server_process():
+    mms_server_processes = list()
+
+    for process in psutil.process_iter():
+        if MMS_NAMESPACE in process.cmdline():
+            mms_server_processes.append(process)
+
+    if not mms_server_processes:
+        raise Exception("mms model server was unsuccessfully started")
+
+    if len(mms_server_processes) > 1:
+        raise Exception("multiple mms model servers are not supported")
+
+    return mms_server_processes[0]

--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -18,6 +18,7 @@ import subprocess
 
 import pkg_resources
 import psutil
+from retrying import retry
 
 import sagemaker_inference
 from sagemaker_inference import default_handler_service, environment, logging, utils
@@ -133,6 +134,8 @@ def _add_sigterm_handler(mms_process):
     signal.signal(signal.SIGTERM, _terminate)
 
 
+# retry for 10 seconds
+@retry(stop_max_delay=10 * 1000)
 def _retrieve_mms_server_process():
     mms_server_processes = list()
 

--- a/test/unit/test_model_server.py
+++ b/test/unit/test_model_server.py
@@ -181,8 +181,9 @@ def test_add_sigterm_handler(signal_call):
     assert isinstance(second_argument, types.FunctionType)
 
 
+@patch('retrying.Retrying.should_reject', return_value=False)
 @patch('psutil.process_iter')
-def test_retrieve_mms_server_process(process_iter):
+def test_retrieve_mms_server_process(process_iter, retry):
     server = Mock()
     server.cmdline.return_value = MMS_NAMESPACE
 
@@ -196,16 +197,18 @@ def test_retrieve_mms_server_process(process_iter):
     assert process == server
 
 
+@patch('retrying.Retrying.should_reject', return_value=False)
 @patch('psutil.process_iter', return_value=list())
-def test_retrieve_mms_server_process_no_server(process_iter):
+def test_retrieve_mms_server_process_no_server(process_iter, retry):
     with pytest.raises(Exception) as e:
         model_server._retrieve_mms_server_process()
 
     assert 'mms model server was unsuccessfully started' in str(e.value)
 
 
+@patch('retrying.Retrying.should_reject', return_value=False)
 @patch('psutil.process_iter')
-def test_retrieve_mms_server_process_too_many_servers(process_iter):
+def test_retrieve_mms_server_process_too_many_servers(process_iter, retry):
     server = Mock()
     second_server = Mock()
     server.cmdline.return_value = MMS_NAMESPACE

--- a/test/unit/test_model_server.py
+++ b/test/unit/test_model_server.py
@@ -15,21 +15,23 @@ import signal
 import types
 
 from mock import Mock, patch
+import pytest
 
 from sagemaker_inference import environment, model_server
+from sagemaker_inference.model_server import MMS_NAMESPACE
 
 PYTHON_PATH = 'python_path'
 DEFAULT_CONFIGURATION = 'default_configuration'
 
-MMS_PROCESS = 'mms_process'
-
 
 @patch('subprocess.call')
-@patch('subprocess.Popen', return_value=MMS_PROCESS)
+@patch('subprocess.Popen')
+@patch('sagemaker_inference.model_server._retrieve_mms_server_process')
 @patch('sagemaker_inference.model_server._add_sigterm_handler')
 @patch('sagemaker_inference.model_server._create_model_server_config_file')
 @patch('sagemaker_inference.model_server._adapt_to_mms_format')
-def test_start_model_server_default_service_handler(adapt, create_config, sigterm, subprocess_popen, subprocess_call):
+def test_start_model_server_default_service_handler(adapt, create_config, sigterm, retrieve, subprocess_popen,
+                                                    subprocess_call):
     model_server.start_model_server()
 
     adapt.assert_called_once_with(model_server.DEFAULT_HANDLER_SERVICE)
@@ -43,21 +45,17 @@ def test_start_model_server_default_service_handler(adapt, create_config, sigter
                               ]
 
     subprocess_popen.assert_called_once_with(mxnet_model_server_cmd)
-    sigterm.assert_called_once_with(MMS_PROCESS)
-
-    tail_cmd = ['tail',
-                '-f',
-                '/dev/null']
-
-    subprocess_call.assert_called_once_with(tail_cmd)
+    sigterm.assert_called_once_with(retrieve.return_value)
 
 
 @patch('subprocess.call')
 @patch('subprocess.Popen')
+@patch('sagemaker_inference.model_server._retrieve_mms_server_process')
 @patch('sagemaker_inference.model_server._add_sigterm_handler')
 @patch('sagemaker_inference.model_server._create_model_server_config_file')
 @patch('sagemaker_inference.model_server._adapt_to_mms_format')
-def test_start_model_server_custom_handler_service(adapt, create_config, sigterm, subprocess_popen, subprocess_call):
+def test_start_model_server_custom_handler_service(adapt, create_config, sigterm, retrieve, subprocess_popen,
+                                                   subprocess_call):
     handler_service = Mock()
 
     model_server.start_model_server(handler_service)
@@ -181,3 +179,45 @@ def test_add_sigterm_handler(signal_call):
     assert len(mock_calls) == 1
     assert first_argument == signal.SIGTERM
     assert isinstance(second_argument, types.FunctionType)
+
+
+@patch('psutil.process_iter')
+def test_retrieve_mms_server_process(process_iter):
+    server = Mock()
+    server.cmdline.return_value = MMS_NAMESPACE
+
+    processes = list()
+    processes.append(server)
+
+    process_iter.return_value = processes
+
+    process = model_server._retrieve_mms_server_process()
+
+    assert process == server
+
+
+@patch('psutil.process_iter', return_value=list())
+def test_retrieve_mms_server_process_no_server(process_iter):
+    with pytest.raises(Exception) as e:
+        model_server._retrieve_mms_server_process()
+
+    assert 'mms model server was unsuccessfully started' in str(e.value)
+
+
+@patch('psutil.process_iter')
+def test_retrieve_mms_server_process_too_many_servers(process_iter):
+    server = Mock()
+    second_server = Mock()
+    server.cmdline.return_value = MMS_NAMESPACE
+    second_server.cmdline.return_value = MMS_NAMESPACE
+
+    processes = list()
+    processes.append(server)
+    processes.append(second_server)
+
+    process_iter.return_value = processes
+
+    with pytest.raises(Exception) as e:
+        model_server._retrieve_mms_server_process()
+
+    assert 'multiple mms model servers are not supported' in str(e.value)


### PR DESCRIPTION
DO NOT MERGE. Still want to do some more testing after PyTorch 1.2 is released first.

*Issue #, if available:*
User running into memory issues due to tail. See for more information: https://github.com/aws/sagemaker-inference-toolkit/issues/9

*Description of changes:*

User ran into an error due to the command "tail -f /dev/null".

The tail call is meant to keep the container running, instead I now wait on the server process to finish or return an error code. The reason why the process that is responsible for starting the mxnet-model-server can't be used to wait is because [MMS starts another subprocess](https://github.com/awslabs/mxnet-model-server/blob/master/mms/model_server.py#L136), which for some reason can't be tracked by calling `children()` on the mms_process. When looking at the parent of that child's process, it points to bash.

For this reason we look for the cmdline that the process was created to do. Which comes from here: https://github.com/awslabs/mxnet-model-server/blob/master/mms/model_server.py#L56

*Testing*
```
flake8: commands succeeded
  twine: commands succeeded
  py27: commands succeeded
  py36: commands succeeded
  congratulations :)
```

MXNet serving
I modified MXNet 1.4.1 CPU Dockerfile to install the modified version of this package and ran the local and SageMaker integration tests.
local
```
tox -e py27 test/integration/local -- --docker-base-name preprod-mxnet-serving --tag 1.4.1-cpu-py2-modified-toolkit --py-version 2 --framework-version 1.4.1 --processor cpu

test/integration/local/test_default_model_fn.py::test_default_model_fn[py2-cpu] PASSED                                                                                                                                                                 [ 20%]
test/integration/local/test_default_model_fn.py::test_default_model_fn_content_type[py2-cpu] algo-1-yhd7y_1  | 2019-10-17 00:14:31,625 [WARN ] W-9000-model-stderr com.amazonaws.ml.mms.wlm.WorkerLifeCycle - [00:14:31] src/nnvm/legacy_json_util.cc:209: Loading symbol saved by previous version v0.11.0. Attempting to upgrade...
PASSED                                                                                                                                                    [ 40%]algo-1-yhd7y_1  | 2019-10-17 00:14:31,628 [WARN ] W-9000-model-stderr com.amazonaws.ml.mms.wlm.WorkerLifeCycle - [00:14:31] src/nnvm/legacy_json_util.cc:217: Symbol successfully upgraded!

test/integration/local/test_gluon_hosting.py::test_gluon_hosting[py2-cpu] PASSED                                                                                                                                                                                                                                                                                                                                                                                                                [ 60%]
test/integration/local/test_hosting.py::test_hosting[py2-cpu] PASSED                                                                                                                                                                                                                                                                                                                                                                                                                            [ 80%]
test/integration/local/test_onnx.py::test_onnx_import[py2-cpu] PASSED                                                                                                                                                                       [100%]

============================================================================================================ 5 passed in 99.73 seconds
```

sagemaker
```
tox -e py36 test/integration/sagemaker -- --aws-id 633083500428 --docker-base-name sagemaker-mxnet-serving --instance-type ml.m4.xlarge --tag 1.4.1-cpu-py2-modified-toolkit

test/integration/sagemaker/test_batch_transform.py::test_batch_transform[py3-cpu] PASSED                                                                                                                                                    [ 33%]
test/integration/sagemaker/test_elastic_inference.py::test_elastic_inference[py3-cpu] SKIPPED                                                                                                                                               [ 66%]
test/integration/sagemaker/test_hosting.py::test_hosting[py3-cpu] PASSED                                                                                                                                                                    [100%]
```

PyTorch
```
test/integration/local/test_serving.py::test_serve_json_npy PASSED                                                                                                                                                                          [ 25%]
test/integration/local/test_serving.py::test_serve_csv PASSED                                                                                                                                                                               [ 50%]
test/integration/local/test_serving.py::test_serve_cpu_model_on_gpu SKIPPED                                                                                                                                                                 [ 75%]
test/integration/local/test_serving.py::test_serving_calls_model_fn_once PASSED                                                                                                                                                             [100%]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
