### PR TITLE
feature: support requirements.txt

### DIFF
--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -139,7 +139,7 @@ def _add_sigterm_handler(mms_process):
 
 def _install_requirements():
     logger.info('installing packages from requirements.txt...')
-    pip_install_cmd = [sys.executable, 'install', '-r', REQUIREMENTS_PATH]
+    pip_install_cmd = [sys.executable, '-m', 'pip', 'install', '-r', REQUIREMENTS_PATH]
 
     try:
         subprocess.check_call(pip_install_cmd)

--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -15,11 +15,13 @@ from __future__ import absolute_import
 import os
 import signal
 import subprocess
+import sys
 
 import pkg_resources
 
 import sagemaker_inference
 from sagemaker_inference import default_handler_service, environment, logging, utils
+from sagemaker_inference.environment import code_dir
 
 logger = logging.get_logger()
 
@@ -31,6 +33,7 @@ DEFAULT_MMS_MODEL_DIRECTORY = os.path.join(os.getcwd(), '.sagemaker/mms/models')
 DEFAULT_MMS_MODEL_NAME = 'model'
 
 PYTHON_PATH_ENV = 'PYTHONPATH'
+REQUIREMENTS_PATH = os.path.join(code_dir, "requirements.txt")
 
 
 def start_model_server(handler_service=DEFAULT_HANDLER_SERVICE):
@@ -45,6 +48,9 @@ def start_model_server(handler_service=DEFAULT_HANDLER_SERVICE):
     """
     _adapt_to_mms_format(handler_service)
     _create_model_server_config_file()
+
+    if os.path.exists(REQUIREMENTS_PATH):
+        _install_requirements()
 
     mxnet_model_server_cmd = ['mxnet-model-server',
                               '--start',
@@ -129,3 +135,14 @@ def _add_sigterm_handler(mms_process):
             pass
 
     signal.signal(signal.SIGTERM, _terminate)
+
+
+def _install_requirements():
+    logger.info('installing packages from requirements.txt...')
+    pip_install_cmd = [sys.executable, 'install', '-r', REQUIREMENTS_PATH]
+
+    try:
+        subprocess.check_call(pip_install_cmd)
+    except subprocess.CalledProcessError:
+        logger.error('failed to install required packages, exiting')
+        raise ValueError('failed to install required packages')

--- a/test/unit/test_model_server.py
+++ b/test/unit/test_model_server.py
@@ -12,11 +12,14 @@
 # language governing permissions and limitations under the License.
 import os
 import signal
+import subprocess
 import types
 
 from mock import Mock, patch
+import pytest
 
 from sagemaker_inference import environment, model_server
+from sagemaker_inference.model_server import REQUIREMENTS_PATH
 
 PYTHON_PATH = 'python_path'
 DEFAULT_CONFIGURATION = 'default_configuration'
@@ -27,13 +30,18 @@ MMS_PROCESS = 'mms_process'
 @patch('subprocess.call')
 @patch('subprocess.Popen', return_value=MMS_PROCESS)
 @patch('sagemaker_inference.model_server._add_sigterm_handler')
+@patch('sagemaker_inference.model_server._install_requirements')
+@patch('os.path.exists', return_value=True)
 @patch('sagemaker_inference.model_server._create_model_server_config_file')
 @patch('sagemaker_inference.model_server._adapt_to_mms_format')
-def test_start_model_server_default_service_handler(adapt, create_config, sigterm, subprocess_popen, subprocess_call):
+def test_start_model_server_default_service_handler(adapt, create_config, exists, install_requirements, sigterm,
+                                                    subprocess_popen, subprocess_call):
     model_server.start_model_server()
 
     adapt.assert_called_once_with(model_server.DEFAULT_HANDLER_SERVICE)
     create_config.assert_called_once_with()
+    exists.assert_called_once_with(REQUIREMENTS_PATH)
+    install_requirements.assert_called_once_with()
 
     mxnet_model_server_cmd = ['mxnet-model-server',
                               '--start',
@@ -181,3 +189,16 @@ def test_add_sigterm_handler(signal_call):
     assert len(mock_calls) == 1
     assert first_argument == signal.SIGTERM
     assert isinstance(second_argument, types.FunctionType)
+
+
+@patch('subprocess.check_call')
+def test_install_requirements(check_call):
+    model_server._install_requirements()
+
+
+@patch('subprocess.check_call', side_effect=subprocess.CalledProcessError(0, "cmd"))
+def test_install_requirements_installation_failed(check_call):
+    with pytest.raises(ValueError) as e:
+        model_server._install_requirements()
+
+    assert 'failed to install required packages' in str(e.value)


### PR DESCRIPTION
DO NOT MERGE. Want to do additional testing after the PyTorch 1.2 release.

*Issue #, if available:*
https://github.com/aws/sagemaker-inference-toolkit/issues/9
https://github.com/aws/sagemaker-python-sdk/issues/957
https://github.com/aws/sagemaker-python-sdk/issues/664

*Description of changes:*
Added code to support installing requirements.txt.

This makes the assumption that the requirements.txt will be in the /opt/ml/model/code/ as defined in the [environments.py](https://github.com/aws/sagemaker-inference-toolkit/blob/master/src/sagemaker_inference/environment.py#L32) and in the [tensorflow-serving-container](https://github.com/aws/sagemaker-tensorflow-serving-container/blob/master/container/sagemaker/serve.py#L32).

The unit tests are very bare... I was able to patch subprocess.check_call, however when I call it with assert_called_once_with, it errors out stating that it was never called... even though the side effect shouldn't happen if that were true.

```
msg = "Expected 'check_call' to be called once. Called 0 times."
```

*Testing*
tox tests
```
flake8: commands succeeded
  twine: commands succeeded
  py27: commands succeeded
  py36: commands succeeded
  congratulations :)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
