### PR TITLE
documentation: Add pull request template and issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: AWS Developer Forums
+    url: https://forums.aws.amazon.com/
+    about: Please ask and answer questions here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+*Testing done:*
+
+## Merge Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._
+
+#### General
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
+- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
+- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
+- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)
+
+#### Tests
+
+- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
+- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
*Description of changes:*
- Adds a template for pull requests
- Adds `config.yml`, which [configures the issue template chooser](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) so that issue templates (added in #30) can be selected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
