### PR TITLE
infra: Do not parallelize unit tests in buildspecs

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -17,7 +17,7 @@ phases:
       - tox -e black-check
 
       # run unit tests
-      - tox -e py27,py36,py37 --parallel all -- test/unit
+      - tox -e py27,py36,py37 -- test/unit
 
       # build dummy container
       - python3 setup.py sdist

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,7 +15,7 @@ phases:
       - tox -e twine
 
       # run unit tests
-      - tox -e py27,py36,py37 --parallel all -- test/unit
+      - tox -e py27,py36,py37 -- test/unit
 
       # build dummy container
       - python setup.py sdist


### PR DESCRIPTION
*Description of changes:*
Parallelizing unit tests in builds seems to cause flakiness. (Noticed this in the release pipeline.) Removing parallelization.

*Testing done:*
Testing with PR build and release pipeline.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
