### PR TITLE
fix: Remove typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_version():
 
 packages = setuptools.find_packages(where="src", exclude=("test",))
 
-required_packages = ["numpy", "six", "typing", "psutil", "retrying==1.3.3"]
+required_packages = ["numpy", "six", "psutil", "retrying==1.3.3"]
 
 # enum is introduced in Python 3.4. Installing enum back port
 if sys.version_info < (3, 4):

--- a/src/sagemaker_inference/decoder.py
+++ b/src/sagemaker_inference/decoder.py
@@ -78,7 +78,6 @@ _decoder_map = {
 
 
 def decode(obj, content_type):
-    # type: (np.array or Iterable or int or float, str) -> np.array
     """Decode an object to one of the default content types to a numpy array.
 
     Args:

--- a/src/sagemaker_inference/decoder.py
+++ b/src/sagemaker_inference/decoder.py
@@ -15,7 +15,6 @@ files and objects to NumPy arrays."""
 from __future__ import absolute_import
 
 import json
-from typing import Iterable  # noqa ignore=F401 imported but unused
 
 import numpy as np
 from six import BytesIO, StringIO

--- a/src/sagemaker_inference/encoder.py
+++ b/src/sagemaker_inference/encoder.py
@@ -15,7 +15,6 @@ to various types of objects and files."""
 from __future__ import absolute_import
 
 import json
-from typing import Iterable  # noqa ignore=F401 imported but unused
 
 import numpy as np
 from six import BytesIO, StringIO

--- a/src/sagemaker_inference/encoder.py
+++ b/src/sagemaker_inference/encoder.py
@@ -22,7 +22,7 @@ from six import BytesIO, StringIO
 from sagemaker_inference import content_types, errors
 
 
-def _array_to_json(array_like):  # type: (np.array or Iterable or int or float) -> str
+def _array_to_json(array_like):
     """Convert an array-like object to JSON.
 
     To understand better what an array-like object is see:
@@ -44,7 +44,7 @@ def _array_to_json(array_like):  # type: (np.array or Iterable or int or float) 
     return json.dumps(array_like, default=default)
 
 
-def _array_to_npy(array_like):  # type: (np.array or Iterable or int or float) -> object
+def _array_to_npy(array_like):
     """Convert an array-like object to the NPY format.
 
     To understand better what an array-like object is see:
@@ -62,7 +62,7 @@ def _array_to_npy(array_like):  # type: (np.array or Iterable or int or float) -
     return buffer.getvalue()
 
 
-def _array_to_csv(array_like):  # type: (np.array or Iterable or int or float) -> str
+def _array_to_csv(array_like):
     """Convert an array-like object to CSV.
 
     To understand better what an array-like object is see:
@@ -88,7 +88,6 @@ _encoder_map = {
 
 
 def encode(array_like, content_type):
-    # type: (np.array or Iterable or int or float, str) -> np.array
     """Encode an array-like object in a specific content_type to a numpy array.
 
     To understand better what an array-like object is see:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-training-toolkit/issues/60

*Description of changes:*
- There is a known conflict between the built-in `typing` package in Python 3.7 and the backported `typing` package available through PyPI.
- Since this toolkit supports both Python 2.7 and 3.7, the `typing` PyPI dependency and all usage of `typing` have been removed.

*Testing done:*
Ran tox locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
