### PR TITLE
fix: include stacktrace when handling an error

### DIFF
--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -73,14 +73,14 @@ class Transformer(object):
         self._output_fn = None
 
     @staticmethod
-    def handle_error(context, inference_exception, tb):
+    def handle_error(context, inference_exception, trace):
         """Set context appropriately for error response.
 
         Args:
             context (mms.context.Context): The inference context.
             inference_exception (sagemaker_inference.errors.BaseInferenceToolkitError): An exception
                 raised during inference, with information for the error response.
-            tb (traceback): The stacktrace of the error.
+            trace (traceback): The stacktrace of the error.
 
         Returns:
             str: The error message and stacktrace from the exception.
@@ -88,7 +88,7 @@ class Transformer(object):
         context.set_response_status(
             code=inference_exception.status_code, phrase=inference_exception.phrase
         )
-        return ["{}\n{}".format(inference_exception.message, tb)]
+        return ["{}\n{}".format(inference_exception.message, trace)]
 
     def transform(self, data, context):
         """Take a request with input data, deserialize it, make a prediction, and return a
@@ -135,14 +135,14 @@ class Transformer(object):
             context.set_response_content_type(0, response_content_type)
             return [response]
         except Exception as e:  # pylint: disable=broad-except
-            tb = traceback.format_exc()
+            trace = traceback.format_exc()
             if isinstance(e, BaseInferenceToolkitError):
-                return self.handle_error(context, e, tb)
+                return self.handle_error(context, e, trace)
             else:
                 return self.handle_error(
                     context,
                     GenericInferenceToolkitError(http_client.INTERNAL_SERVER_ERROR, str(e)),
-                    tb,
+                    trace,
                 )
 
     def validate_and_initialize(self, model_dir=environment.model_dir):  # type: () -> None

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -16,10 +16,11 @@ requests.
 """
 from __future__ import absolute_import
 
+import importlib
 import traceback
 
 try:
-    from importlib.util import find_spec
+    from importlib.util import find_spec  # pylint: disable=ungrouped-imports
 except ImportError:
     import imp  # noqa: F401
 
@@ -38,7 +39,7 @@ except ImportError:
         except ImportError:
             return None
 
-import importlib  # pylint: disable=ungrouped-imports
+
 from six.moves import http_client
 
 from sagemaker_inference import content_types, environment, utils

--- a/test/container/dummy/mme_handler_service.py
+++ b/test/container/dummy/mme_handler_service.py
@@ -98,7 +98,7 @@ class ModelHandler(object):
             )
             self.mx_model.set_params(arg_params, aux_params, allow_missing=True)
             with open("synset.txt", "r") as f:
-                self.labels = [l.rstrip() for l in f]
+                self.labels = [ln.rstrip() for ln in f]
         except (mx.base.MXNetError, RuntimeError) as error:
             if re.search("Failed to allocate (.*) Memory", str(error), re.IGNORECASE):
                 logging.error("Memory allocation exception: {}".format(error))

--- a/test/container/dummy/mme_handler_service.py
+++ b/test/container/dummy/mme_handler_service.py
@@ -98,7 +98,7 @@ class ModelHandler(object):
             )
             self.mx_model.set_params(arg_params, aux_params, allow_missing=True)
             with open("synset.txt", "r") as f:
-                self.labels = [ln.rstrip() for ln in f]
+                self.labels = [line.rstrip() for line in f]
         except (mx.base.MXNetError, RuntimeError) as error:
             if re.search("Failed to allocate (.*) Memory", str(error), re.IGNORECASE):
                 logging.error("Memory allocation exception: {}".format(error))

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -234,6 +234,7 @@ def test_handle_validate_and_initialize_error(env, validate_user_module):
 
     response = transformer.transform(data, context)
     assert test_error_message in str(response)
+    assert "Traceback (most recent call last)" in str(response)
     context.set_response_status.assert_called_with(
         code=http_client.INTERNAL_SERVER_ERROR, phrase=test_error_message
     )
@@ -268,6 +269,7 @@ def test_handle_validate_and_initialize_user_error(env, validate_user_module):
 
     response = transformer.transform(data, context)
     assert test_error_message in str(response)
+    assert "Traceback (most recent call last)" in str(response)
     context.set_response_status.assert_called_with(
         code=http_client.FORBIDDEN, phrase=test_error_message
     )


### PR DESCRIPTION
*Issue #, if available:*
#50

*Description of changes:*
When handling an inference error, we don't include the stacktrace in the response (see #50)

*Testing done:*
* unit tests
* built the MXNet image and ran a local endpoint with an inference script designed to fail

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
