### PR TITLE
documentation: fix package name in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more information, see the Amazon SageMaker Developer Guide sections on [buil
 To install this library in your Docker image, add the following line to your [Dockerfile](https://docs.docker.com/engine/reference/builder/):
 
 ``` dockerfile
-RUN pip3 install multi-model-server sagemaker-inference-toolkit
+RUN pip3 install multi-model-server sagemaker-inference
 ```
 
 [Here is an example](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/advanced_functionality/multi_model_bring_your_own/container/Dockerfile) of a Dockerfile that installs SageMaker Inference Toolkit.


### PR DESCRIPTION
The package exists under the name 'sagemaker-inference'. This change fixes the name for the pip install command from nonexistant 'sagemaker-inference-toolkit'

*Issue #, if available:*
None

*Description of changes:*
Changed the name of package to 'sagemaker-inference' in the pip install command in README.md

*Testing done:*
None, documentation change 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
