### PR TITLE
Torchserve support for PyTorch Inference

### DIFF
--- a/src/sagemaker_inference/etc/default-ts.properties
+++ b/src/sagemaker_inference/etc/default-ts.properties
@@ -1,0 +1,4 @@
+# Based on: https://github.com/awslabs/mxnet-model-server/blob/master/docs/configuration.md
+enable_envvars_config=true
+decode_input_request=false
+load_models=ALL

--- a/src/sagemaker_inference/etc/ts.log4j.properties
+++ b/src/sagemaker_inference/etc/ts.log4j.properties
@@ -1,0 +1,50 @@
+log4j.rootLogger = WARN, console
+
+log4j.appender.console = org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target = System.out
+log4j.appender.console.layout = org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern = %d{ISO8601} [%-5p] %t %c - %m%n
+
+log4j.appender.access_log = org.apache.log4j.RollingFileAppender
+log4j.appender.access_log.File = ${LOG_LOCATION}/access_log.log
+log4j.appender.access_log.MaxFileSize = 10MB
+log4j.appender.access_log.MaxBackupIndex = 5
+log4j.appender.access_log.layout = org.apache.log4j.PatternLayout
+log4j.appender.access_log.layout.ConversionPattern = %d{ISO8601} - %m%n
+
+log4j.appender.ts_log = org.apache.log4j.RollingFileAppender
+log4j.appender.ts_log.File = ${LOG_LOCATION}/ts_log.log
+log4j.appender.ts_log.MaxFileSize = 10MB
+log4j.appender.ts_log.MaxBackupIndex = 5
+log4j.appender.ts_log.layout = org.apache.log4j.PatternLayout
+log4j.appender.ts_log.layout.ConversionPattern = %d{ISO8601} [%-5p] %t %c - %m%n
+
+log4j.appender.ts_metrics = org.apache.log4j.RollingFileAppender
+log4j.appender.ts_metrics.File = ${METRICS_LOCATION}/ts_metrics.log
+log4j.appender.ts_metrics.MaxFileSize = 10MB
+log4j.appender.ts_metrics.MaxBackupIndex = 5
+log4j.appender.ts_metrics.layout = org.apache.log4j.PatternLayout
+log4j.appender.ts_metrics.layout.ConversionPattern = %d{ISO8601} - %m%n
+
+log4j.appender.model_log = org.apache.log4j.RollingFileAppender
+log4j.appender.model_log.File = ${LOG_LOCATION}/model_log.log
+log4j.appender.model_log.MaxFileSize = 10MB
+log4j.appender.model_log.MaxBackupIndex = 5
+log4j.appender.model_log.layout = org.apache.log4j.PatternLayout
+log4j.appender.model_log.layout.ConversionPattern = %d{ISO8601} [%-5p] %c - %m%n
+
+log4j.appender.model_metrics = org.apache.log4j.RollingFileAppender
+log4j.appender.model_metrics.File = ${METRICS_LOCATION}/model_metrics.log
+log4j.appender.model_metrics.MaxFileSize = 10MB
+log4j.appender.model_metrics.MaxBackupIndex = 5
+log4j.appender.model_metrics.layout = org.apache.log4j.PatternLayout
+log4j.appender.model_metrics.layout.ConversionPattern = %d{ISO8601} - %m%n
+
+log4j.logger.com.amazonaws.ml.ts = INFO, ts_log
+log4j.logger.ACCESS_LOG = INFO, access_log
+log4j.logger.TS_METRICS = WARN, ts_metrics
+log4j.logger.MODEL_METRICS = WARN, model_metrics
+log4j.logger.MODEL_LOG = WARN, model_log
+
+log4j.logger.org.apache = OFF
+log4j.logger.io.netty = ERROR

--- a/src/sagemaker_inference/model_server_utils.py
+++ b/src/sagemaker_inference/model_server_utils.py
@@ -1,0 +1,66 @@
+import os
+import signal
+import subprocess
+import sys
+
+import pkg_resources
+import psutil
+from retrying import retry
+
+import sagemaker_inference
+from sagemaker_inference import environment, logging, utils
+from sagemaker_inference.environment import code_dir
+
+PYTHON_PATH_ENV = "PYTHONPATH"
+logger = logging.get_logger()
+REQUIREMENTS_PATH = os.path.join(code_dir, "requirements.txt")
+
+def add_sigterm_handler(mms_process):
+    def _terminate(signo, frame):  # pylint: disable=unused-argument
+        try:
+            os.kill(mms_process.pid, signal.SIGTERM)
+        except OSError:
+            pass
+
+    signal.signal(signal.SIGTERM, _terminate)
+
+    
+def set_python_path():
+    # MMS handles code execution by appending the export path, provided
+    # to the model archiver, to the PYTHONPATH env var.
+    # The code_dir has to be added to the PYTHONPATH otherwise the
+    # user provided module can not be imported properly.
+    code_dir_path = "{}:".format(environment.code_dir)
+
+    if PYTHON_PATH_ENV in os.environ:
+        os.environ[PYTHON_PATH_ENV] = code_dir_path + os.environ[PYTHON_PATH_ENV]
+    else:
+        os.environ[PYTHON_PATH_ENV] = code_dir_path
+
+def install_requirements():
+    logger.info("installing packages from requirements.txt...")
+    pip_install_cmd = [sys.executable, "-m", "pip", "install", "-r", REQUIREMENTS_PATH]
+
+    try:
+        subprocess.check_call(pip_install_cmd)
+    except subprocess.CalledProcessError:
+        logger.error("failed to install required packages, exiting")
+        raise ValueError("failed to install required packages")
+
+
+# retry for 10 seconds
+@retry(stop_max_delay=10 * 1000)
+def retrieve_model_server_process(namespace):
+    model_server_processes = list()
+
+    for process in psutil.process_iter():
+        if namespace in process.cmdline():
+            model_server_processes.append(process)
+
+    if not model_server_processes:
+        raise Exception("model server was unsuccessfully started")
+
+    if len(model_server_processes) > 1:
+        raise Exception("multiple model servers are not supported")
+
+    return model_server_processes[0]

--- a/test/unit/test_model_server_utils.py
+++ b/test/unit/test_model_server_utils.py
@@ -1,0 +1,115 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import signal
+import subprocess
+import types
+
+from mock import Mock, patch
+import pytest
+
+from sagemaker_inference import environment, torchserve, model_server_utils
+from sagemaker_inference.torchserve import TS_NAMESPACE, REQUIREMENTS_PATH
+
+PYTHON_PATH = "python_path"
+DEFAULT_CONFIGURATION = "default_configuration"
+
+@patch.dict(os.environ, {torchserve.PYTHON_PATH_ENV: PYTHON_PATH}, clear=True)
+def test_set_existing_python_path():
+    torchserve.set_python_path()
+
+    code_dir_path = "{}:".format(environment.code_dir)
+
+    assert os.environ[torchserve.PYTHON_PATH_ENV] == code_dir_path + PYTHON_PATH
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_new_python_path():
+    torchserve.set_python_path()
+
+    code_dir_path = "{}:".format(environment.code_dir)
+
+    assert os.environ[torchserve.PYTHON_PATH_ENV] == code_dir_path
+
+
+@patch("signal.signal")
+def testadd_sigterm_handler(signal_call):
+    ts = Mock()
+
+    torchserve.add_sigterm_handler(ts)
+
+    mock_calls = signal_call.mock_calls
+    first_argument = mock_calls[0][1][0]
+    second_argument = mock_calls[0][1][1]
+
+    assert len(mock_calls) == 1
+    assert first_argument == signal.SIGTERM
+    assert isinstance(second_argument, types.FunctionType)
+
+
+@patch("subprocess.check_call")
+def testinstall_requirements(check_call):
+    torchserve.install_requirements()
+
+
+@patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(0, "cmd"))
+def testinstall_requirements_installation_failed(check_call):
+    with pytest.raises(ValueError) as e:
+        torchserve.install_requirements()
+
+    assert "failed to install required packages" in str(e.value)
+
+
+@patch("retrying.Retrying.should_reject", return_value=False)
+@patch("psutil.process_iter")
+def test_retrieve_model_server_process(process_iter, retry):
+    server = Mock()
+    server.cmdline.return_value = TS_NAMESPACE
+
+    processes = list()
+    processes.append(server)
+
+    process_iter.return_value = processes
+
+    process = model_server_utils.retrieve_model_server_process(TS_NAMESPACE)
+
+    assert process == server
+
+
+@patch("retrying.Retrying.should_reject", return_value=False)
+@patch("psutil.process_iter", return_value=list())
+def test_retrieve_model_server_process_no_server(process_iter, retry):
+    with pytest.raises(Exception) as e:
+        model_server_utils.retrieve_model_server_process(TS_NAMESPACE)
+
+    assert "model server was unsuccessfully started" in str(e.value)
+
+
+@patch("retrying.Retrying.should_reject", return_value=False)
+@patch("psutil.process_iter")
+def test_retrieve_model_server_process_too_many_servers(process_iter, retry):
+    server = Mock()
+    second_server = Mock()
+    server.cmdline.return_value = TS_NAMESPACE
+    second_server.cmdline.return_value = TS_NAMESPACE
+
+    processes = list()
+    processes.append(server)
+    processes.append(second_server)
+
+    process_iter.return_value = processes
+
+    with pytest.raises(Exception) as e:
+        torchserve.retrieve_model_server_process(TS_NAMESPACE)
+
+    assert "multiple model servers are not supported" in str(e.value)

--- a/test/unit/test_torchserve.py
+++ b/test/unit/test_torchserve.py
@@ -1,0 +1,184 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import signal
+import subprocess
+import types
+
+from mock import Mock, patch
+import pytest
+
+from sagemaker_inference import environment, torchserve, model_server_utils
+from sagemaker_inference.torchserve import TS_NAMESPACE, REQUIREMENTS_PATH
+
+PYTHON_PATH = "python_path"
+DEFAULT_CONFIGURATION = "default_configuration"
+
+
+@patch("subprocess.call")
+@patch("subprocess.Popen")
+@patch("sagemaker_inference.torchserve.retrieve_model_server_process")
+@patch("sagemaker_inference.torchserve.add_sigterm_handler")
+@patch("sagemaker_inference.torchserve.install_requirements")
+@patch("os.path.exists", return_value=True)
+@patch("sagemaker_inference.torchserve._create_torchserve_config_file")
+@patch("sagemaker_inference.torchserve._adapt_to_ts_format")
+def test_start_torchserve_default_service_handler(
+    adapt,
+    create_config,
+    exists,
+    install_requirements,
+    sigterm,
+    retrieve,
+    subprocess_popen,
+    subprocess_call,
+):
+    torchserve.start_model_server()
+
+    adapt.assert_called_once_with(torchserve.DEFAULT_TS_HANDLER_SERVICE)
+    create_config.assert_called_once_with()
+    exists.assert_called_once_with(REQUIREMENTS_PATH)
+    install_requirements.assert_called_once_with()
+
+    ts_model_server_cmd = [
+        "torchserve",
+        "--start",
+        "--model-store",
+        torchserve.MODEL_STORE,
+        "--ts-config",
+        torchserve.TS_CONFIG_FILE,
+        "--log-config",
+        torchserve.DEFAULT_TS_LOG_FILE,
+        "--models",
+        "model.mar"
+    ]
+
+    subprocess_popen.assert_called_once_with(ts_model_server_cmd)
+    retrieve.assert_called_once_with(torchserve.TS_NAMESPACE)
+    sigterm.assert_called_once_with(retrieve.return_value)
+
+
+@patch("subprocess.call")
+@patch("subprocess.Popen")
+@patch("sagemaker_inference.torchserve.retrieve_model_server_process")
+@patch("sagemaker_inference.torchserve.add_sigterm_handler")
+@patch("sagemaker_inference.torchserve._create_torchserve_config_file")
+@patch("sagemaker_inference.torchserve._adapt_to_ts_format")
+def test_start_torchserve_custom_handler_service(
+    adapt, create_config, sigterm, retrieve, subprocess_popen, subprocess_call
+):
+    handler_service = Mock()
+
+    torchserve.start_model_server(handler_service)
+
+    adapt.assert_called_once_with(handler_service)
+
+
+@patch("sagemaker_inference.torchserve.set_python_path")
+@patch("subprocess.check_call")
+@patch("os.makedirs")
+@patch("os.path.exists", return_value=False)
+def test_adapt_to_ts_format(path_exists, make_dir, subprocess_check_call, set_python_path):
+    handler_service = Mock()
+
+    torchserve._adapt_to_ts_format(handler_service)
+
+    path_exists.assert_called_once_with(torchserve.DEFAULT_TS_MODEL_DIRECTORY)
+    make_dir.assert_called_once_with(torchserve.DEFAULT_TS_MODEL_DIRECTORY)
+
+    model_archiver_cmd = [
+        "torch-model-archiver",
+        "--model-name",
+        torchserve.DEFAULT_TS_MODEL_NAME,
+        "--handler",
+        handler_service,
+        #importlib.import_module(DEFAULT_TS_HANDLER_SERVICE).__file__,
+        "--serialized-file",
+        os.path.join(environment.model_dir, torchserve.DEFAULT_TS_MODEL_SERIALIZED_FILE),
+        "--export-path",
+        torchserve.DEFAULT_TS_MODEL_DIRECTORY,
+        "--extra-files",
+        os.path.join(environment.model_dir, environment.Environment().module_name + ".py"),
+        "--version",
+        "1",
+    ]
+
+    subprocess_check_call.assert_called_once_with(model_archiver_cmd)
+    subprocess_check_call.assert_called_once()
+    set_python_path.assert_called_once_with()
+
+
+@patch("sagemaker_inference.torchserve.set_python_path")
+@patch("subprocess.check_call")
+@patch("os.makedirs")
+@patch("os.path.exists", return_value=True)
+def test_adapt_to_ts_format_existing_path(
+    path_exists, make_dir, subprocess_check_call, set_python_path
+):
+    handler_service = Mock()
+
+    torchserve._adapt_to_ts_format(handler_service)
+
+    path_exists.assert_called_once_with(torchserve.DEFAULT_TS_MODEL_DIRECTORY)
+    make_dir.assert_not_called()
+
+
+@patch("sagemaker_inference.torchserve._generate_ts_config_properties")
+@patch("sagemaker_inference.utils.write_file")
+def test_create_torchserve_config_file(write_file, generate_ts_config_props):
+    torchserve._create_torchserve_config_file()
+
+    write_file.assert_called_once_with(
+        torchserve.TS_CONFIG_FILE, generate_ts_config_props.return_value
+    )
+
+
+@patch("sagemaker_inference.utils.read_file", return_value=DEFAULT_CONFIGURATION)
+@patch("sagemaker_inference.environment.Environment")
+def test_generate_ts_config_properties(env, read_file):
+    torchserve_timeout = "model_server_timeout"
+    torchserve_workers = "model_server_workers"
+    http_port = "http_port"
+
+    env.return_value.model_server_timeout = torchserve_timeout
+    env.return_value.model_server_workers = torchserve_workers
+    env.return_value.inference_http_port = http_port
+
+    ts_config_properties = torchserve._generate_ts_config_properties()
+
+    inference_address = "inference_address=http://0.0.0.0:{}\n".format(http_port)
+    server_timeout = "default_response_timeout={}\n".format(torchserve_timeout)
+    workers = "default_workers_per_model={}\n".format(torchserve_workers)
+
+    read_file.assert_called_once_with(torchserve.DEFAULT_TS_CONFIG_FILE)
+
+    assert ts_config_properties.startswith(DEFAULT_CONFIGURATION)
+    assert inference_address in ts_config_properties
+    assert server_timeout in ts_config_properties
+    assert workers in ts_config_properties
+
+
+@patch("sagemaker_inference.utils.read_file", return_value=DEFAULT_CONFIGURATION)
+@patch("sagemaker_inference.environment.Environment")
+def test_generate_ts_config_properties_default_workers(env, read_file):
+    env.return_value.torchserve_workers = None
+
+    ts_config_properties = torchserve._generate_ts_config_properties()
+
+    workers = "default_workers_per_model={}".format(None)
+
+    read_file.assert_called_once_with(torchserve.DEFAULT_TS_CONFIG_FILE)
+
+    assert ts_config_properties.startswith(DEFAULT_CONFIGURATION)
+    assert workers not in ts_config_properties
+


### PR DESCRIPTION
### Torchserve support for PyTorch Inference

This is part of 3 PRs in sagemaker-inference-toolkit / sagemaker-pytorch-inference-toolkit / dlc to add support for TorchServe in Sagmaker.

Other 2 PRs which depend on this : https://github.com/aws/sagemaker-pytorch-inference-toolkit/pull/79 / https://github.com/aws/deep-learning-containers/pull/347

### Testing done

* Unit tests
* The torchserve support is primarlty consumed by sagemaker-pytorch-inference-toolkit. Integration tests were performed against the consuming package to ensure that existing contract works. More details in https://github.com/aws/sagemaker-pytorch-inference-toolkit/pull/79 


#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
