### PR TITLE
fix: remove prohibited characters from error response

### DIFF
--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -90,7 +90,7 @@ class Transformer(object):
         stack_trace = utils.remove_crlf(trace)
 
         context.set_response_status(code=inference_exception.status_code, phrase=phrase)
-        return [message, stack_trace]
+        return ["{} {}".format(message, stack_trace)]
 
     def transform(self, data, context):
         """Take a request with input data, deserialize it, make a prediction, and return a

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -90,7 +90,7 @@ class Transformer(object):
         stack_trace = utils.remove_crlf(trace)
 
         context.set_response_status(code=inference_exception.status_code, phrase=phrase)
-        return ["{}\n{}".format(message, stack_trace)]
+        return [message, stack_trace]
 
     def transform(self, data, context):
         """Take a request with input data, deserialize it, make a prediction, and return a

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -85,10 +85,12 @@ class Transformer(object):
         Returns:
             str: The error message and stacktrace from the exception.
         """
-        context.set_response_status(
-            code=inference_exception.status_code, phrase=inference_exception.phrase
-        )
-        return ["{}\n{}".format(inference_exception.message, trace)]
+        phrase = utils.remove_crlf(inference_exception.phrase)
+        message = utils.remove_crlf(inference_exception.message)
+        stack_trace = utils.remove_crlf(trace)
+
+        context.set_response_status(code=inference_exception.status_code, phrase=phrase)
+        return ["{}\n{}".format(message, stack_trace)]
 
     def transform(self, data, context):
         """Take a request with input data, deserialize it, make a prediction, and return a

--- a/src/sagemaker_inference/utils.py
+++ b/src/sagemaker_inference/utils.py
@@ -92,7 +92,7 @@ def remove_crlf(illegal_string):
     Returns:
         str: The input string with the prohibited characters removed.
     """
-    prohibited = ["\r", "\n", ":"]
+    prohibited = ("\r", "\n")
 
     sanitized_string = illegal_string
 

--- a/src/sagemaker_inference/utils.py
+++ b/src/sagemaker_inference/utils.py
@@ -79,3 +79,24 @@ def parse_accept(accept):
             understand.
     """
     return accept.replace(" ", "").split(",")
+
+
+def remove_crlf(illegal_string):
+    """Removes characters prohibited by the MMS dependency Netty.
+
+    https://github.com/netty/netty/issues/8312
+
+    Args:
+        illegal_string: The string containing prohibited characters.
+
+    Returns:
+        str: The input string with the prohibited characters removed.
+    """
+    prohibited = ["\r", "\n", ":"]
+
+    sanitized_string = illegal_string
+
+    for character in prohibited:
+        sanitized_string = sanitized_string.replace(character, " ")
+
+    return sanitized_string

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -16,6 +16,7 @@ import pytest
 from sagemaker_inference.utils import (
     parse_accept,
     read_file,
+    remove_crlf,
     retrieve_content_type_header,
     write_file,
 )
@@ -92,3 +93,10 @@ def test_content_type_header(content_type_key):
 def test_parse_accept(input, expected):
     actual = parse_accept(input)
     assert actual == expected
+
+
+def test_remove_crlf():
+    illegal_string = "test:\r\nstring"
+    sanitized_string = "test   string"
+
+    assert sanitized_string == remove_crlf(illegal_string)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -97,6 +97,6 @@ def test_parse_accept(input, expected):
 
 def test_remove_crlf():
     illegal_string = "test:\r\nstring"
-    sanitized_string = "test   string"
+    sanitized_string = "test:  string"
 
     assert sanitized_string == remove_crlf(illegal_string)


### PR DESCRIPTION
*Issue #, if available:*
When an inference error occurs, MMS logs the following message:
```
java.lang.IllegalArgumentException: reasonPhrase contains one of the following prohibited characters: \r\n:
```

The root cause of this issue is actually from Netty, which is a dependency of MMS:
- https://github.com/netty/netty/issues/8312
- https://github.com/netty/netty/blob/0cde4d9cb4d19ddc0ecafc5be7c5f7c781a1f6e9/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java#L552

*Description of changes:*
As a workaround, we remove the offending characters from the error message.

*Testing done:*
- Added a unit test.
- Manual testing with a PyTorch inference container deployed to an endpoint.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
