### PR TITLE
fix: clean up stack trace and sanitize only response phrase

### DIFF
--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -85,12 +85,11 @@ class Transformer(object):
         Returns:
             str: The error message and stacktrace from the exception.
         """
-        phrase = utils.remove_crlf(inference_exception.phrase)
-        message = utils.remove_crlf(inference_exception.message)
-        stack_trace = utils.remove_crlf(trace)
-
-        context.set_response_status(code=inference_exception.status_code, phrase=phrase)
-        return ["{} {}".format(message, stack_trace)]
+        context.set_response_status(
+            code=inference_exception.status_code,
+            phrase=utils.remove_crlf(inference_exception.phrase),
+        )
+        return ["{}\n{}".format(inference_exception.message, trace)]
 
     def transform(self, data, context):
         """Take a request with input data, deserialize it, make a prediction, and return a


### PR DESCRIPTION
*Description of changes:*
- https://github.com/aws/sagemaker-inference-toolkit/pull/62 fixed an issue with prohibited characters by removing them from the inference exception response. This fixed the error, but it caused the stack trace to be unreadable.
- After further testing, only the response phrase needed to be sanitized. This PR leaves the stack trace and message with new line characters to improve readability.

*Testing done:*
- Manual testing with a PyTorch inference container deployed to an endpoint.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
