### PR TITLE
fix: add model-archiver and multi-model-server to required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,15 @@ def read_version():
 
 packages = setuptools.find_packages(where="src", exclude=("test",))
 
-required_packages = ["numpy", "six", "psutil", "retrying==1.3.3", "scipy"]
+required_packages = [
+    "model-archiver",
+    "multi-model-server",
+    "numpy",
+    "six",
+    "psutil",
+    "retrying==1.3.3",
+    "scipy",
+]
 
 # enum is introduced in Python 3.4. Installing enum back port
 if sys.version_info < (3, 4):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-inference-toolkit/pull/66

*Description of changes:*
The toolkit expects that `model-archiver` and `multi-model-server` are installed and fails otherwise. This change updates the `required_packages` accordingly.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
