### PR TITLE
fix: Increase timeout for starting model server to 10 minutes

### DIFF
--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -189,8 +189,8 @@ def _install_requirements():
         raise ValueError("failed to install required packages")
 
 
-# retry for 10 seconds
-@retry(stop_max_delay=10 * 1000)
+# retry for 10 minutes
+@retry(stop_max_delay=10 * 60 * 1000)
 def _retrieve_mms_server_process():
     mms_server_processes = list()
 


### PR DESCRIPTION
*Description of changes:*
Increased timeout for starting model server to 10 minutes. This is due to an issue under heavy CPU load that sometimes arises where it would not start up in time, in SageMaker Multi-Model Endpoint scenarios with large models.

*Testing done:*
Ran unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
