### PR TITLE
fix: Increase timeout for starting model server to 10 minutes

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   variables:
-    LC_ALL="C.UTF-8"
-    LANG="C.UTF-8"
+    LC_ALL: "C.UTF-8"
+    LANG: "C.UTF-8"
 
 phases:
   pre_build:

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    LC_ALL="C.UTF-8"
+    LANG="C.UTF-8"
+
 phases:
   pre_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   variables:
-    LC_ALL="C.UTF-8"
-    LANG="C.UTF-8"
+    LC_ALL: "C.UTF-8"
+    LANG: "C.UTF-8"
 
 phases:
   pre_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -35,4 +35,4 @@ phases:
       - cd ../..
 
       # run local integration tests
-      - IGNORE_COVERAGE=- tox -e py27,py36,py37 -- test/integration/local
+      - IGNORE_COVERAGE=- tox -e py27,py36,py37 -- -s test/integration/local 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    LC_ALL="C.UTF-8"
+    LANG="C.UTF-8"
+
 phases:
   pre_build:
     commands:

--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -190,7 +190,7 @@ def _install_requirements():
 
 
 # retry for 10 minutes
-@retry(stop_max_delay=10 * 60 * 1000)
+@retry(wait_fixed=1000, stop_max_delay=10 * 60 * 1000)
 def _retrieve_mms_server_process():
     mms_server_processes = list()
 

--- a/src/sagemaker_inference/model_server.py
+++ b/src/sagemaker_inference/model_server.py
@@ -189,8 +189,8 @@ def _install_requirements():
         raise ValueError("failed to install required packages")
 
 
-# retry for 10 seconds
-@retry(stop_max_delay=10 * 1000)
+# retry for 10 minutes
+@retry(stop_max_delay=10 * 60 * 1000)
 def _retrieve_mms_server_process():
     mms_server_processes = list()
 

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -39,13 +39,14 @@ def container():
 
         attempts = 0
         while attempts < 10:
-            time.sleep(60)
+            time.sleep(3)
             try:
                 requests.get(PING_URL)
                 break
             except:  # noqa: E722
                 attempts += 1
                 pass
+            time.sleep(60)
         yield proc.pid
     finally:
         subprocess.check_call("docker rm -f sagemaker-inference-toolkit-test".split())

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -40,6 +40,7 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
+            print("printing after sleeping for 3 sec. attempts:" + attempts)
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -38,8 +38,8 @@ def container():
         proc = subprocess.Popen(command.split(), stdout=sys.stdout, stderr=subprocess.STDOUT)
 
         attempts = 0
-        while attempts < 5:
-            time.sleep(3)
+        while attempts < 10:
+            time.sleep(60)
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -46,7 +46,8 @@ def container():
                 break
             except:  # noqa: E722
                 attempts += 1
-                time.sleep(60)
+                print("In the except block")
+                # time.sleep(60)
                 pass
         yield proc.pid
     finally:

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -40,7 +40,7 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
-            print("printing after sleeping for 3 sec. attempts:" + attempts)
+            print("printing after sleeping for 3 sec. attempts:" + str(attempts))
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -40,14 +40,11 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
-            print("printing after sleeping for 3 sec. attempts:" + str(attempts))
             try:
                 requests.get(PING_URL)
                 break
             except:  # noqa: E722
                 attempts += 1
-                print("In the except block")
-                # time.sleep(60)
                 pass
         yield proc.pid
     finally:

--- a/test/integration/local/test_dummy_multi_model.py
+++ b/test/integration/local/test_dummy_multi_model.py
@@ -45,8 +45,8 @@ def container():
                 break
             except:  # noqa: E722
                 attempts += 1
+                time.sleep(60)
                 pass
-            time.sleep(60)
         yield proc.pid
     finally:
         subprocess.check_call("docker rm -f sagemaker-inference-toolkit-test".split())

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -39,13 +39,14 @@ def container():
 
         attempts = 0
         while attempts < 10:
-            time.sleep(60)
+            time.sleep(3)
             try:
                 requests.get(PING_URL)
                 break
             except:  # noqa: E722
                 attempts += 1
                 pass
+            time.sleep(60)
         yield proc.pid
     finally:
         subprocess.check_call("docker rm -f sagemaker-inference-toolkit-test".split())

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -40,6 +40,7 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
+            print("printing after sleeping for 3 sec. attempts:" + attempts)
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -38,8 +38,8 @@ def container():
         proc = subprocess.Popen(command.split(), stdout=sys.stdout, stderr=subprocess.STDOUT)
 
         attempts = 0
-        while attempts < 5:
-            time.sleep(3)
+        while attempts < 10:
+            time.sleep(60)
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -46,7 +46,8 @@ def container():
                 break
             except:  # noqa: E722
                 attempts += 1
-                time.sleep(60)
+                print("In the except block")
+                # time.sleep(60)
                 pass
         yield proc.pid
     finally:

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -40,7 +40,7 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
-            print("printing after sleeping for 3 sec. attempts:" + attempts)
+            print("printing after sleeping for 3 sec. attempts:" + str(attempts))
             try:
                 requests.get(PING_URL)
                 break

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -40,14 +40,11 @@ def container():
         attempts = 0
         while attempts < 10:
             time.sleep(3)
-            print("printing after sleeping for 3 sec. attempts:" + str(attempts))
             try:
                 requests.get(PING_URL)
                 break
             except:  # noqa: E722
                 attempts += 1
-                print("In the except block")
-                # time.sleep(60)
                 pass
         yield proc.pid
     finally:

--- a/test/integration/local/test_mxnet_multi_model.py
+++ b/test/integration/local/test_mxnet_multi_model.py
@@ -45,8 +45,8 @@ def container():
                 break
             except:  # noqa: E722
                 attempts += 1
+                time.sleep(60)
                 pass
-            time.sleep(60)
         yield proc.pid
     finally:
         subprocess.check_call("docker rm -f sagemaker-inference-toolkit-test".split())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Increased timeout for starting model server to 10 minutes. This is due to an issue under heavy CPU load that sometimes arises where it would not start up in time, in SageMaker Multi-Model Endpoint scenarios with large models.

*Testing done:*
 Ran unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
