### PR TITLE
Modify transform function to support batch inference

### DIFF
--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -124,7 +124,7 @@ class Transformer(object):
 
             response_list = []
 
-            for i in range(len(data)):
+            for _ in range(len(data)):
                 input_data = data[0].get("body")
 
                 request_processor = context.request_processor[0]

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -142,7 +142,7 @@ class Transformer(object):
                 result = self._run_handler_function(
                     self._transform_fn, *(self._model, input_data, content_type, accept)
                 )
- 
+
                 response = result
                 response_content_type = accept
 

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -124,8 +124,8 @@ class Transformer(object):
 
             response_list = []
 
-            for _ in range(len(data)):
-                input_data = data[0].get("body")
+            for i in range(len(data)):
+                input_data = data[i].get("body")
 
                 request_processor = context.request_processor[0]
 

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -122,34 +122,40 @@ class Transformer(object):
             model_dir = properties.get("model_dir")
             self.validate_and_initialize(model_dir=model_dir, context=context)
 
-            input_data = data[0].get("body")
+            response_list = []
 
-            request_processor = context.request_processor[0]
+            for i in range(len(data)):
+                input_data = data[0].get("body")
 
-            request_property = request_processor.get_request_properties()
-            content_type = utils.retrieve_content_type_header(request_property)
-            accept = request_property.get("Accept") or request_property.get("accept")
+                request_processor = context.request_processor[0]
 
-            if not accept or accept == content_types.ANY:
-                accept = self._environment.default_accept
+                request_property = request_processor.get_request_properties()
+                content_type = utils.retrieve_content_type_header(request_property)
+                accept = request_property.get("Accept") or request_property.get("accept")
 
-            if content_type in content_types.UTF8_TYPES:
-                input_data = input_data.decode("utf-8")
+                if not accept or accept == content_types.ANY:
+                    accept = self._environment.default_accept
+                
+                if content_type in content_types.UTF8_TYPES:
+                    input_data = input_data.decode("utf-8")
 
-            result = self._run_handler_function(
-                self._transform_fn, *(self._model, input_data, content_type, accept)
-            )
+                result = self._run_handler_function(
+                    self._transform_fn, *(self._model, input_data, content_type, accept)
+                )
+                
+                response = result
+                response_content_type = accept
 
-            response = result
-            response_content_type = accept
+                if isinstance(result, tuple):
+                    # handles tuple for backwards compatibility
+                    response = result[0]
+                    response_content_type = result[1]
 
-            if isinstance(result, tuple):
-                # handles tuple for backwards compatibility
-                response = result[0]
-                response_content_type = result[1]
+                context.set_response_content_type(0, response_content_type)
 
-            context.set_response_content_type(0, response_content_type)
-            return [response]
+                response_list.append(response)
+
+            return response_list
         except Exception as e:  # pylint: disable=broad-except
             trace = traceback.format_exc()
             if isinstance(e, BaseInferenceToolkitError):

--- a/src/sagemaker_inference/transformer.py
+++ b/src/sagemaker_inference/transformer.py
@@ -135,14 +135,14 @@ class Transformer(object):
 
                 if not accept or accept == content_types.ANY:
                     accept = self._environment.default_accept
-                
+
                 if content_type in content_types.UTF8_TYPES:
                     input_data = input_data.decode("utf-8")
 
                 result = self._run_handler_function(
                     self._transform_fn, *(self._model, input_data, content_type, accept)
                 )
-                
+ 
                 response = result
                 response_content_type = accept
 

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -124,7 +124,7 @@ def test_batch_transform(validate, retrieve_content_type_header, run_handler, ac
 
     result = transformer.transform(data, context)
 
-    assert validate.assert_called_once()
+    validate.assert_called_once()
     retrieve_content_type_header.assert_called_with(request_property)
     assert retrieve_content_type_header.call_count == 2
     run_handler.assert_called_with(

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -124,12 +124,16 @@ def test_batch_transform(validate, retrieve_content_type_header, run_handler, ac
 
     result = transformer.transform(data, context)
 
-    validate.assert_called_once()
-    retrieve_content_type_header.assert_called_once_with(request_property)
-    run_handler.assert_called_once_with(
+    assert validate.called
+    assert validate.call_count == 2
+    retrieve_content_type_header.assert_called_with(request_property)
+    assert retrieve_content_type_header.call_count == 2
+    run_handler.assert_called_with(
         transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, ACCEPT
     )
-    context.set_response_content_type.assert_called_once_with(0, ACCEPT)
+    assert run_handler.call_count == 2
+    context.set_response_content_type.assert_called_with(0, ACCEPT)
+    assert context.set_response_content_type.call_count == 2
     assert isinstance(result, list)
     assert result == [RESULT, RESULT]
 

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -124,8 +124,7 @@ def test_batch_transform(validate, retrieve_content_type_header, run_handler, ac
 
     result = transformer.transform(data, context)
 
-    assert validate.called
-    assert validate.call_count == 2
+    assert validate.assert_called_once()
     retrieve_content_type_header.assert_called_with(request_property)
     assert retrieve_content_type_header.call_count == 2
     run_handler.assert_called_with(

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -102,6 +102,7 @@ def test_transform(validate, retrieve_content_type_header, run_handler, accept_k
     assert isinstance(result, list)
     assert result[0] == RESULT
 
+
 @pytest.mark.parametrize("accept_key", ["Accept", "accept"])
 @patch("sagemaker_inference.transformer.Transformer._run_handler_function", return_value=RESULT)
 @patch("sagemaker_inference.utils.retrieve_content_type_header", return_value=CONTENT_TYPE)
@@ -131,6 +132,7 @@ def test_batch_transform(validate, retrieve_content_type_header, run_handler, ac
     context.set_response_content_type.assert_called_once_with(0, ACCEPT)
     assert isinstance(result, list)
     assert result == [RESULT, RESULT]
+
 
 @patch("sagemaker_inference.transformer.Transformer._run_handler_function")
 @patch("sagemaker_inference.utils.retrieve_content_type_header", return_value=CONTENT_TYPE)


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes the issue described here in PT inference toolkit repo, since the fix can be applied at the transform function in the sagemaker inference toolkit, which PT toolkit inherits from.

*Description of changes:*
1. This PR fixes the issue where the transform() function drops all but one requests when running prediction.
2. This PR adds a transform() function to override the transform() function from the sagemaker-inference-toolkit. It loops through the input data and runs _transform_fn() on each input. Then, it appends the response to a list. When all inputs are processed, the list is returned.

Config used:
```
env_variables_dict = {
    "SAGEMAKER_TS_BATCH_SIZE": "3",
    "SAGEMAKER_TS_MAX_BATCH_DELAY": "10000",
    "SAGEMAKER_TS_MIN_WORKERS": "1",
    "SAGEMAKER_TS_MAX_WORKERS": "1",
}
```

Requests sent to SM endpoint as:
```
import multiprocessing


def invoke(endpoint_name):
    return predictor.predict(
        "{Bloomberg has decided to publish a new report on global economic situation.}"
    )


endpoint_name = predictor.endpoint_name
pool = multiprocessing.Pool(3)
results = pool.map(invoke, 5 * [endpoint_name])
pool.close()
pool.join()
print(results)
```

Logs:
```
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,606 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Flushing req. to backend at: 1658385260606
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,608 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Backend received inference at: 1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,608 [WARN ] W-9000-model_1.0-stderr MODEL_LOG - Downloading: 100%|██████████| 28.0/28.0 [00:00<00:00, 40.9kB/s]
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,609 [WARN ] W-9000-model_1.0-stderr MODEL_LOG - Truncation was not explicitly activated but `max_length` is provided a specific value, please use `truncation=True` to explicitly truncate examples to max length. Defaulting to 'longest_first' truncation strategy. If you encode pairs of sequences (GLUE-style) with the tokenizer you can select this strategy more precisely by providing a specific strategy to `truncation`.
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,829 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT1
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT2
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Got input Data: {Bloomberg has decided to publish a new report on global economic situation.}
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Backend response time: 223
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PRED SequenceClassifierOutput(loss=None, logits=tensor([[ 0.1999, -0.2964]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PREDICTION ['Not Accepted']
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT1
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,831 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT2
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,830 [INFO ] W-9000-model_1.0 ACCESS_LOG - /172.18.0.1:41768 "POST /invocations HTTP/1.1" 200 235
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,831 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Got input Data: {Bloomberg has decided to publish a new report on global economic situation.}
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,831 [INFO ] W-9000-model_1.0 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385250
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,831 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PRED SequenceClassifierOutput(loss=None, logits=tensor([[ 0.1999, -0.2964]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,831 [INFO ] W-9000-model_1.0 TS_METRICS - QueueTime.ms:0|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PREDICTION ['Not Accepted']
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT1
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0 ACCESS_LOG - /172.18.0.1:41766 "POST /invocations HTTP/1.1" 200 237
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT2
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385250
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Got input Data: {Bloomberg has decided to publish a new report on global economic situation.}
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0 TS_METRICS - QueueTime.ms:0|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,832 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PRED SequenceClassifierOutput(loss=None, logits=tensor([[ 0.1999, -0.2964]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,833 [INFO ] W-9000-model_1.0 ACCESS_LOG - /172.18.0.1:41772 "POST /invocations HTTP/1.1" 200 238
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,833 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PREDICTION ['Not Accepted']
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,833 [INFO ] W-9000-model_1.0 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385250
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,833 [INFO ] W-9000-model_1.0-stdout MODEL_METRICS - PredictionTime.Milliseconds:220.84|#ModelName:model,Level:Model|#hostname:4eaca41fef85,requestID:48456f5d-451c-4b5b-a377-b70c0a630510,b2f48fcb-5e16-47d2-a592-a08b03794a1e,0d9d4a84-bd30-409e-b6ab-abe5d975efe9,timestamp:1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,833 [INFO ] W-9000-model_1.0 TS_METRICS - QueueTime.ms:0|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:20,834 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerThreadTime.ms:5|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385260
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,879 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Flushing req. to backend at: 1658385270879
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,880 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Backend received inference at: 1658385270
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,981 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT1
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,981 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT2
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,981 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Backend response time: 101
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Got input Data: {Bloomberg has decided to publish a new report on global economic situation.}
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0 ACCESS_LOG - /172.18.0.1:41768 "POST /invocations HTTP/1.1" 200 10104
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PRED SequenceClassifierOutput(loss=None, logits=tensor([[ 0.1999, -0.2964]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385250
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PREDICTION ['Not Accepted']
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT1
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,982 [INFO ] W-9000-model_1.0 TS_METRICS - QueueTime.ms:10000|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385270
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - INPUT2
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0 ACCESS_LOG - /172.18.0.1:41766 "POST /invocations HTTP/1.1" 200 10105
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Got input Data: {Bloomberg has decided to publish a new report on global economic situation.}
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0 TS_METRICS - Requests2XX.Count:1|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385250
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PRED SequenceClassifierOutput(loss=None, logits=tensor([[ 0.1999, -0.2964]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0 TS_METRICS - QueueTime.ms:10000|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385270
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - PREDICTION ['Not Accepted']
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,983 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerThreadTime.ms:3|#Level:Host|#hostname:4eaca41fef85,timestamp:1658385270
lep82nflth-algo-1-7djas  | 2022-07-21T06:34:30,984 [INFO ] W-9000-model_1.0-stdout MODEL_METRICS - PredictionTime.Milliseconds:100.58|#ModelName:model,Level:Model|#hostname:4eaca41fef85,requestID:6a42623e-e66c-4681-a508-a297b519ee39,bbea0728-5968-43e7-abd4-cdbe9cc61455,timestamp:1658385270
[b'["Not Accepted"]', b'["Not Accepted"]', b'["Not Accepted"]', b'["Not Accepted"]', b'["Not Accepted"]']
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
