### PR TITLE
Pass context from handler service to handler function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ To use the SageMaker Inference Toolkit, you need to do the following:
 
     class DefaultPytorchInferenceHandler(default_inference_handler.DefaultInferenceHandler):
 
-        def default_model_fn(self, model_dir):
+        def default_model_fn(self, model_dir, context=None):
             """Loads a model. For PyTorch, a default function to load a model cannot be provided.
             Users should provide customized model_fn() in script.
 
             Args:
                 model_dir: a directory where model is saved.
+                context (obj): the request context (default: None).
 
             Returns: A PyTorch model.
             """
@@ -60,40 +61,54 @@ To use the SageMaker Inference Toolkit, you need to do the following:
             See documentation for model_fn at https://github.com/aws/sagemaker-python-sdk
             """))
 
-        def default_input_fn(self, input_data, content_type):
+        def default_input_fn(self, input_data, content_type, context=None):
             """A default input_fn that can handle JSON, CSV and NPZ formats.
 
             Args:
                 input_data: the request payload serialized in the content_type format
                 content_type: the request content_type
+                context (obj): the request context (default: None).
 
             Returns: input_data deserialized into torch.FloatTensor or torch.cuda.FloatTensor depending if cuda is available.
             """
             return decoder.decode(input_data, content_type)
 
-        def default_predict_fn(self, data, model):
+        def default_predict_fn(self, data, model, context=None):
             """A default predict_fn for PyTorch. Calls a model on data deserialized in input_fn.
             Runs prediction on GPU if cuda is available.
 
             Args:
                 data: input data (torch.Tensor) for prediction deserialized by input_fn
                 model: PyTorch model loaded in memory by model_fn
+                context (obj): the request context (default: None).
 
             Returns: a prediction
             """
             return model(input_data)
 
-        def default_output_fn(self, prediction, accept):
+        def default_output_fn(self, prediction, accept, context=None):
             """A default output_fn for PyTorch. Serializes predictions from predict_fn to JSON, CSV or NPY format.
 
             Args:
                 prediction: a prediction result from predict_fn
                 accept: type which the output data needs to be serialized
+                context (obj): the request context (default: None).
 
             Returns: output data serialized
             """
             return encoder.encode(prediction, accept)
     ```
+    Note, passing context as an argument to the handler functions is optional. Customer can choose to omit context from the function declaration if it's not needed in the runtime. For example, the following handler function declarations will also work:
+
+    ```
+    def default_model_fn(self, model_dir)
+
+    def default_input_fn(self, input_data, content_type)
+
+    def default_predict_fn(self, data, model)
+
+    def default_output_fn(self, prediction, accept)
+    ``` 
 
 2.  Implement a handler service that is executed by the model server.
     ([Here is an example](https://github.com/aws/sagemaker-pytorch-serving-container/blob/master/src/sagemaker_pytorch_serving_container/handler_service.py) of a handler service.)

--- a/src/sagemaker_inference/default_handler_service.py
+++ b/src/sagemaker_inference/default_handler_service.py
@@ -63,4 +63,4 @@ class DefaultHandlerService(object):
         else:
             os.environ[PYTHON_PATH_ENV] = code_dir_path
 
-        self._service.validate_and_initialize(model_dir=model_dir)
+        self._service.validate_and_initialize(model_dir=model_dir, context=context)

--- a/src/sagemaker_inference/default_inference_handler.py
+++ b/src/sagemaker_inference/default_inference_handler.py
@@ -21,11 +21,12 @@ from sagemaker_inference import decoder, encoder, errors, utils
 class DefaultInferenceHandler(object):
     """Bare-bones implementation of default inference functions."""
 
-    def default_model_fn(self, model_dir):
+    def default_model_fn(self, model_dir, context=None):
         """Function responsible for loading the model.
 
         Args:
             model_dir (str): The directory where model files are stored.
+            context (obj): the request context (default: None).
 
         Returns:
             obj: the loaded model.
@@ -40,12 +41,14 @@ class DefaultInferenceHandler(object):
             )
         )
 
-    def default_input_fn(self, input_data, content_type):  # pylint: disable=no-self-use
+    def default_input_fn(self, input_data, content_type, context=None):
+        # pylint: disable=unused-argument, no-self-use
         """Function responsible for deserializing the input data into an object for prediction.
 
         Args:
             input_data (obj): the request data.
             content_type (str): the request content type.
+            context (obj): the request context (default: None).
 
         Returns:
             obj: data ready for prediction.
@@ -53,12 +56,13 @@ class DefaultInferenceHandler(object):
         """
         return decoder.decode(input_data, content_type)
 
-    def default_predict_fn(self, data, model):
+    def default_predict_fn(self, data, model, context=None):
         """Function responsible for model predictions.
 
         Args:
-            model (obj): model loaded by the model_fn
-            data: deserialized data returned by the input_fn
+            model (obj): model loaded by the model_fn.
+            data: deserialized data returned by the input_fn.
+            context (obj): the request context (default: None).
 
         Returns:
             obj: prediction result.
@@ -73,12 +77,13 @@ class DefaultInferenceHandler(object):
             )
         )
 
-    def default_output_fn(self, prediction, accept):  # pylint: disable=no-self-use
+    def default_output_fn(self, prediction, accept, context=None):  # pylint: disable=no-self-use
         """Function responsible for serializing the prediction result to the desired accept type.
 
         Args:
             prediction (obj): prediction result returned by the predict_fn.
             accept (str): accept header expected by the client.
+            context (obj): the request context (default: None).
 
         Returns:
             obj: prediction data.

--- a/test/unit/test_default_inference_handler.py
+++ b/test/unit/test_default_inference_handler.py
@@ -10,7 +10,7 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import patch
+from mock import Mock, patch
 import pytest
 
 from sagemaker_inference import content_types
@@ -19,7 +19,8 @@ from sagemaker_inference.default_inference_handler import DefaultInferenceHandle
 
 @patch("sagemaker_inference.decoder.decode")
 def test_default_input_fn(loads):
-    assert DefaultInferenceHandler().default_input_fn(42, content_types.JSON)
+    context = Mock()
+    assert DefaultInferenceHandler().default_input_fn(42, content_types.JSON, context)
 
     loads.assert_called_with(42, content_types.JSON)
 
@@ -34,7 +35,8 @@ def test_default_input_fn(loads):
 )
 @patch("sagemaker_inference.encoder.encode", lambda prediction, accept: prediction**2)
 def test_default_output_fn(accept, expected_content_type):
-    result, content_type = DefaultInferenceHandler().default_output_fn(2, accept)
+    context = Mock()
+    result, content_type = DefaultInferenceHandler().default_output_fn(2, accept, context)
     assert result == 4
     assert content_type == expected_content_type
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ max-complexity = 15
 
 ignore =
     E203,  # whitespace before ':': Black disagrees with and explicitly violates this.
-    W503  # Ignore line break before binary operator, since Black violates this.
+    W503   # Ignore line break before binary operator, since Black violates this.
 
 builtins = FileNotFoundError
 
@@ -62,7 +62,7 @@ commands =
 [testenv:flake8]
 basepython = python3
 deps =
-    flake8
+    flake8==4.0.1
     pep8-naming
     flake8-import-order
 commands = flake8


### PR DESCRIPTION
*Issue #, if available:*
MMS and TorchServe store request information in [context](https://github.com/awslabs/multi-model-server/blob/master/mms/context.py#L16) object and pass it to the [handler service](https://github.com/aws/sagemaker-inference-toolkit/blob/master/src/sagemaker_inference/default_handler_service.py#L52) function. This PR further pass the context to the handler function so that users can use those information in the custom handler function. 

One particular use case is multi-GPU inference for PyTorch and MXNet. Currently handler functions[ statically select](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/src/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py#L121-123) the same GPU device and assign all data/model to that single device even on a multi-GPU host. MMS and TorchServe dynamically select GPU device and store that information in `context`. By passing `context` to handler function, users can choose to assign data/model to different GPUs and utilize all GPU resources. 

Below is an example of `input_fn` that process and assign data to device:
```
## current handler function
def input_fn(self, input_data, content_type):
        ## data processing 
        np_array = decoder.decode(input_data, content_type)
        tensor = torch.FloatTensor(np_array) if content_type in content_types.UTF8_TYPES 
                    else torch.from_numpy(np_array)
               
        ## select device statically
        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
        
        ## copy data to device
        return tensor.to(device)
``` 

```
## new handler function with context
def input_fn(self, input_data, content_type, context):
        ## data processing 
        np_array = decoder.decode(input_data, content_type)
        tensor = torch.FloatTensor(np_array) if content_type in content_types.UTF8_TYPES 
                    else torch.from_numpy(np_array)
               
        ## select device dynamically
        device = torch.device("cuda:" + str(context.system_properties.get("gpu_id")) if torch.cuda.is_available() else "cpu")
        
        ## copy data to device
        return tensor.to(device)
```

After this PR, handler functions with/without context will be both supported. So that it won’t break existing use cases. 
```
input_fn(input_data, content_type)  # should still work
```

*Description of changes:*
- Pass context from handler service to handler functions
- Add context as an input argument to default handler functions
- Add helper function to support handler functions with/without context
- Pin flake8 version to avoid breaking changes

*Testing done:*
- Added unittest to make sure context gets passed and both new/old handler functions work properly.
- Conducted end-to-end local test to run a PT inference job on sagmaker. Tested on handler functions with and without context. Created 9 worker on a 8 GPU host:

With context passed, workers were assigned to different gpus as expected:
```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A    396466      C   /opt/conda/bin/python3.8         1659MiB |
|    1   N/A  N/A    396465      C   /opt/conda/bin/python3.8         1659MiB |
|    1   N/A  N/A    396467      C   /opt/conda/bin/python3.8         1659MiB |
|    2   N/A  N/A    396470      C   /opt/conda/bin/python3.8         1659MiB |
|    3   N/A  N/A    396462      C   /opt/conda/bin/python3.8         1659MiB |
|    4   N/A  N/A    396469      C   /opt/conda/bin/python3.8         1659MiB |
|    5   N/A  N/A    396463      C   /opt/conda/bin/python3.8         1659MiB |
|    6   N/A  N/A    396468      C   /opt/conda/bin/python3.8         1659MiB |
|    7   N/A  N/A    396464      C   /opt/conda/bin/python3.8         1659MiB |
+-----------------------------------------------------------------------------+
```
Without context, all workers loaded model to GPU 0 and it burns out the dedicated memory (14936MiB / 16384MiB)
```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A    220119      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220120      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220121      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220122      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220123      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220124      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220125      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220126      C   /opt/conda/bin/python3.8         1659MiB |
|    0   N/A  N/A    220127      C   /opt/conda/bin/python3.8         1659MiB |
+-----------------------------------------------------------------------------+
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
