### PR TITLE
[DRAFT] Support CustomAttributes / request context in handler function overrides

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ required_packages = ["numpy", "six", "psutil", "retrying==1.3.3", "scipy"]
 # enum is introduced in Python 3.4. Installing enum back port
 if sys.version_info < (3, 4):
     required_packages.append("enum34 >= 1.1.6")
+# inspect.signature is introduced in Python 3.3. Installing funcsigs back port
+if sys.version_info < (3, 3):
+    required_packages.append("funcsigs >= 1.0.2")
 
 PKG_NAME = "sagemaker_inference"
 


### PR DESCRIPTION
**Issue #, if available:** #110

**Description of changes:**

Initial draft of a non-breaking option to support passing an extra "request context" parameter to handler override functions (`transform_fn`, `input_fn`, `predict_fn`, `output_fn`), **ONLY** when the signature of the provided function includes the extra parameter.

This should allow script mode users to access additional request context (such as the SageMaker CustomAttributes header) without breaking implementations using the existing function APIs.

Outstanding TODOs (hoping for input from reviewers!) include:

- [ ] Agree the scope of the additional "context" object - the raw `context` object as per `Transformer.transform()` seems maybe too broad & not very user-friendly? I'm not even sure what API it offers
- [ ] Validate the approach
- [ ] Understand & complete relevant doc updates & downstream library updates (e.g. add the parameter in default handler fns here and in other libraries like the PyTorch and HuggingFace toolkits too? Update SageMaker Python SDK docs when new DLCs are available with this change built in?)

**Testing done:**

Added some unit tests to show initial non-breaking-ness, but would be nice to get an integration test too maybe?

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] ~I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)~
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-inference-toolkit/blob/master/README.rst)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
