### PR TITLE
fix: transform function to support proper batch inference

### DIFF
--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -96,7 +96,7 @@ def test_transform(validate, retrieve_content_type_header, run_handler, accept_k
     validate.assert_called_once()
     retrieve_content_type_header.assert_called_once_with(request_property)
     run_handler.assert_called_once_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, ACCEPT
+        transformer._transform_fn, MODEL, [INPUT_DATA], CONTENT_TYPE, ACCEPT
     )
     context.set_response_content_type.assert_called_once_with(0, ACCEPT)
     assert isinstance(result, list)
@@ -125,16 +125,13 @@ def test_batch_transform(validate, retrieve_content_type_header, run_handler, ac
     result = transformer.transform(data, context)
 
     validate.assert_called_once()
-    retrieve_content_type_header.assert_called_with(request_property)
-    assert retrieve_content_type_header.call_count == 2
-    run_handler.assert_called_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, ACCEPT
+    retrieve_content_type_header.assert_called_once_with(request_property)
+    run_handler.assert_called_once_with(
+        transformer._transform_fn, MODEL, [INPUT_DATA, INPUT_DATA], CONTENT_TYPE, ACCEPT
     )
-    assert run_handler.call_count == 2
-    context.set_response_content_type.assert_called_with(0, ACCEPT)
-    assert context.set_response_content_type.call_count == 2
+    context.set_response_content_type.assert_called_once_with(0, ACCEPT)
     assert isinstance(result, list)
-    assert result == [RESULT, RESULT]
+    assert result[0] == RESULT
 
 
 @patch("sagemaker_inference.transformer.Transformer._run_handler_function")
@@ -161,7 +158,7 @@ def test_transform_no_accept(validate, retrieve_content_type_header, run_handler
 
     validate.assert_called_once()
     run_handler.assert_called_once_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, DEFAULT_ACCEPT
+        transformer._transform_fn, MODEL, [INPUT_DATA], CONTENT_TYPE, DEFAULT_ACCEPT
     )
 
 
@@ -189,7 +186,7 @@ def test_transform_any_accept(validate, retrieve_content_type_header, run_handle
 
     validate.assert_called_once()
     run_handler.assert_called_once_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, DEFAULT_ACCEPT
+        transformer._transform_fn, MODEL, [INPUT_DATA], CONTENT_TYPE, DEFAULT_ACCEPT
     )
 
 
@@ -218,7 +215,7 @@ def test_transform_decode(validate, retrieve_content_type_header, run_handler, c
 
     input_data.decode.assert_called_once_with("utf-8")
     run_handler.assert_called_once_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, content_type, ACCEPT
+        transformer._transform_fn, MODEL, [INPUT_DATA], content_type, ACCEPT
     )
 
 
@@ -245,7 +242,7 @@ def test_transform_tuple(validate, retrieve_content_type_header, run_handler):
     result = transformer.transform(data, context)
 
     run_handler.assert_called_once_with(
-        transformer._transform_fn, MODEL, INPUT_DATA, CONTENT_TYPE, ACCEPT
+        transformer._transform_fn, MODEL, [INPUT_DATA], CONTENT_TYPE, ACCEPT
     )
     context.set_response_content_type.assert_called_once_with(0, run_handler()[1])
     assert isinstance(result, list)


### PR DESCRIPTION
*Issue #, if available:*
This PR is related to #108 and #123.

*Description of changes:*
As mentioned in #123, the batch inference provided by torchserve literally provides batch inference in a 'batch' format. However, the batch inference implementation in #108 simply runs a single inference through a loop. This is not a correct implementation of batch inference. [TorchServe's documentation](https://pytorch.org/serve/batch_inference_with_ts.html) on batch inference, shows an [example](https://github.com/pytorch/serve/blob/master/examples/Huggingface_Transformers/Transformer_handler_generalized.py) where the developer handles this logic and feeds the entire input batch to the model. 

If I understand correctly, keeping the batch inference implementation in its current state would be deceptive to the user. 

To make batch inference work correctly, we've modified it so that a list of requests can be sent to _transform_fn() in list format. 

However, the current implementation requires modifications to related functions such as default_input_fn() and associated documentation, examples, etc. As far as I know, there is no better alternative, so it would be good to review and discuss this PR before proceeding with modifications to other functions. 


*Testing done:*
yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-inference-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

